### PR TITLE
Expose .cache([cacheStrategy]) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ setTimeout(function () {
 }, 10000)
 ```
 
+The second `cache` argument is also exposed with `.cache()`
+```js
+var cached = require('cached-callback').cache()
+var get = cached(function (id, callback) {
+  request('http://example.com/'+id, callback)
+}
+```
+
 ### Custom caching method
 Caches the result with a custom caching method.
 This example caches the result for 20 seconds.

--- a/index.js
+++ b/index.js
@@ -40,9 +40,10 @@
   function invoke (cb, a, length) {
     switch (length) {
       case 0: cb(); break
-      case 1: cb(a[0], a[1]); break
-      case 2: cb(a[0], a[1], a[2]); break
-      case 3: cb(a[0], a[1], a[2], a[3]); break
+      case 1: cb(a[0]); break
+      case 2: cb(a[0], a[1]); break
+      case 3: cb(a[0], a[1], a[2]); break
+      case 4: cb(a[0], a[1], a[2], a[3]); break
       default: cb.apply(null, a)
     }
   }

--- a/index.js
+++ b/index.js
@@ -60,6 +60,13 @@
     }
   }
 
+  cachedCallback.cache = function configureCache (cacher) {
+    if (typeof cacher === 'undefined') cacher = true
+    return function cachedCallbackWithCache (getter) {
+      return cachedCallback(getter, cacher)
+    }
+  }
+
   if (typeof exports === 'object') {
     module.exports = cachedCallback
   } else if (typeof define === 'function' && define.amd) {

--- a/test.js
+++ b/test.js
@@ -48,6 +48,18 @@ var third = debounce(function (a, cb) {})
 assert.throws(function () { third('a', 'b') }, /The last argument has to be a callback/)
 assert.doesNotThrow(function () { third('a', callback) })
 
+// test debounce when no key is used
+var called = 0
+var without = debounce(function (cb) {
+  setTimeout(function () { cb(++called) }, 1)
+})
+
+without(function (val) { assert.equal(val, 1) })
+without(function (val) { assert.equal(val, 1) })
+setTimeout(function () {
+  without(function (args) { assert.equal(args, 2) })
+}, 2)
+
 //
 // Check cache
 var i = 0
@@ -67,6 +79,20 @@ setTimeout(function () {
     assert.equal(val, 0)
   })
 }, 10)
+
+// test cache setter cachedCallback.cache(true)
+// test caching when no key is passed
+var cachedCallback = require('./').cache(true)
+var times = 0
+var persistent = cachedCallback(function (cb) {
+  setTimeout(function () { cb(++times) }, 1)
+})
+
+persistent(function (val) { assert.equal(val, 1) })
+persistent(function (val) { assert.equal(val, 1) })
+setTimeout(function () {
+  persistent(function (val) { assert.equal(val, 1) })
+}, 2)
 
 process.on('exit', function (exitCode) {
   if (!exitCode) console.log('All tests succeeded.')


### PR DESCRIPTION
... as alias to `cachedCallback(getter, [cacheStrategy])`
use it like

``` js
var lruCache = require('lru-cache')(50)
var cached = require('cached-callback').cache(lruCache)
var get = cached(function (id, callback) {
  request('http://example.com/'+ id, callback)
})

get('index.html', console.log)
```
